### PR TITLE
changes to paper code

### DIFF
--- a/enclone_paper/src/bin/dperfection.rs
+++ b/enclone_paper/src/bin/dperfection.rs
@@ -1,0 +1,61 @@
+// Given a file of junction nucleotide sequences, determine the distribution of dperfection
+// values, defined as dperfect/junction-region-length.  See dperfect.rs.
+//
+// usage: dperfection junction-region-file
+
+use enclone_paper::dperfect::dperfect;
+use io_utils::*;
+use pretty_trace::*;
+use std::env;
+use std::io::BufRead;
+use vdj_ann_ref::human_ref;
+
+fn main() {
+    PrettyTrace::new().on();
+    let args: Vec<String> = env::args().collect();
+    let f = open_for_read![&args[1]];
+
+    // Fetch junction regions.
+
+    let mut juns = Vec::<Vec<u8>>::new();
+    for line in f.lines() {
+        let s = line.unwrap();
+        juns.push(s.as_bytes().to_vec());
+    }
+
+    // Fetch D gene reference sequences.
+
+    let mut ds = Vec::<Vec<u8>>::new();
+    let href = human_ref();
+    let mut hlines = Vec::<String>::new();
+    for line in href.lines() {
+        hlines.push(line.to_string());
+    }
+    for i in (0..hlines.len()).step_by(2) {
+        if hlines[i].contains("|D-REGION|IG|") {
+            ds.push(hlines[i + 1].as_bytes().to_vec());
+        }
+    }
+
+    // Compute dperfection.
+
+    let mut dps = Vec::<f64>::new();
+    for i in 0..juns.len() {
+        let dperf = dperfect(&juns[i], &ds);
+        dps.push(dperf as f64 / juns[i].len() as f64);
+    }
+
+    // Print histogram.
+
+    let mut buckets = vec![0; 11];
+    for i in 0..dps.len() {
+        let b = (dps[i] * 10.0).floor() as usize;
+        buckets[b] += 1;
+    }
+    println!("\ndperfection%\tdata%");
+    for i in 0..=10 {
+        let label = if i < 10 { format!("{}-", 10 * i) } else { format!("100") };
+        println!("{label}\t{:.1}", 100.0 * buckets[i] as f64 / dps.len() as f64);
+    }
+    println!("");
+}

--- a/enclone_paper/src/bin/dperfection.rs
+++ b/enclone_paper/src/bin/dperfection.rs
@@ -58,8 +58,15 @@ fn main() {
     }
     println!("\ndperfection%\tdata%");
     for i in 0..=10 {
-        let label = if i < 10 { format!("{}-", 10 * i) } else { format!("100") };
-        println!("{label}\t{:.1}", 100.0 * buckets[i] as f64 / dps.len() as f64);
+        let label = if i < 10 {
+            format!("{}-", 10 * i)
+        } else {
+            format!("100")
+        };
+        println!(
+            "{label}\t{:.1}",
+            100.0 * buckets[i] as f64 / dps.len() as f64
+        );
     }
     println!("");
 }

--- a/enclone_paper/src/bin/dperfection.rs
+++ b/enclone_paper/src/bin/dperfection.rs
@@ -2,6 +2,10 @@
 // values, defined as dperfect/junction-region-length.  See dperfect.rs.
 //
 // usage: dperfection junction-region-file
+//
+// How to create input file from per_cell_stuff, e.g. for d1:
+//
+// cat per_cell_stuff | cut -d, -f2,7,16 | grep d1 | grep ",0," | cut -d, -f3 > d1_cdr3_dna1_naive
 
 use enclone_paper::dperfect::dperfect;
 use io_utils::*;

--- a/enclone_paper/src/bin/insertion_analysis.rs
+++ b/enclone_paper/src/bin/insertion_analysis.rs
@@ -77,6 +77,31 @@ fn main() {
 
     // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 
+    // Compute mean substitution rate for naive cells.
+
+    let mut rates = Vec::<f64>::new();
+    for k in 0..data.len() {
+        let dref = data[k].5;
+        if dref == 0 {
+            let matches = data[k].6;
+            let subs = data[k].7;
+            if subs + matches > 0 {
+                let rate = subs as f64 / (subs + matches) as f64;
+                rates.push(rate);
+            }
+        }
+    }
+    let mut mean_sub_rate = 0.0;
+    for k in 0..rates.len() {
+        mean_sub_rate += rates[k];
+    }
+    mean_sub_rate /= rates.len() as f64;
+    println!("\nmean junction substitution rate for naive cells = {:.1}%",
+        100.0 * mean_sub_rate
+    );
+
+    // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
+
     // For naive cells with junction insertion length zero, show the substitution and
     // substitution rate distribution.
 

--- a/enclone_paper/src/bin/insertion_analysis.rs
+++ b/enclone_paper/src/bin/insertion_analysis.rs
@@ -96,7 +96,8 @@ fn main() {
         mean_sub_rate += rates[k];
     }
     mean_sub_rate /= rates.len() as f64;
-    println!("\nmean junction substitution rate for naive cells = {:.1}%",
+    println!(
+        "\nmean junction substitution rate for naive cells = {:.1}%",
         100.0 * mean_sub_rate
     );
 

--- a/enclone_paper/src/bin/olga_splice.rs
+++ b/enclone_paper/src/bin/olga_splice.rs
@@ -556,10 +556,12 @@ fn main() {
     println!("CDRH3 length distribution");
     let mut bins = vec![0; 100];
     let mut total = 0;
+    let mut total_len = 0;
     for k in 0..cdrh3_lens.len() {
         let len = cdrh3_lens[k];
         bins[len / 5] += 1;
         total += 1;
+        total_len += len;
     }
     for i in 0..bins.len() {
         if bins[i] > 0 {
@@ -571,6 +573,7 @@ fn main() {
             );
         }
     }
+    println!("mean CDRH3 length = {:.1}", total_len as f64 / total as f64);
     let mut total = 0;
     for i in 0..jun_ins.len() {
         total += jun_ins[i];

--- a/enclone_paper/src/bin/olga_splice.rs
+++ b/enclone_paper/src/bin/olga_splice.rs
@@ -89,7 +89,6 @@ fn main() {
     // However, this leader has stop codons.  Therefore we put in a FAKE leader, that for
     // IGHV3-11.
 
-    /*
     refnames.push("IGHV3-43D".to_string());
     utr.push(false);
     refs.push(
@@ -130,7 +129,6 @@ fn main() {
             .to_vec(),
     );
     utr.push(false);
-    */
     let nref = refs.len();
     let mut refdata = RefData::new();
     let ext_ref = String::new();

--- a/enclone_paper/src/bin/olga_splice.rs
+++ b/enclone_paper/src/bin/olga_splice.rs
@@ -89,6 +89,7 @@ fn main() {
     // However, this leader has stop codons.  Therefore we put in a FAKE leader, that for
     // IGHV3-11.
 
+    /*
     refnames.push("IGHV3-43D".to_string());
     utr.push(false);
     refs.push(
@@ -129,6 +130,7 @@ fn main() {
             .to_vec(),
     );
     utr.push(false);
+    */
     let nref = refs.len();
     let mut refdata = RefData::new();
     let ext_ref = String::new();
@@ -326,7 +328,7 @@ fn main() {
                     v_ref_id,
                     j_ref_id,
                     &seq,
-                    &ann,
+                    &annv,
                     &strme(&cdr3x[0].1),
                     &refdata,
                     &Vec::new(),

--- a/enclone_paper/src/bin/olga_splice.rs
+++ b/enclone_paper/src/bin/olga_splice.rs
@@ -88,6 +88,10 @@ fn main() {
     // GAGTGAGAAAAACTGGATTTGTGTGGCATTTTCTGATAACGGTGTCCTTCTGTTTGCAGGTGTCCAGTGT.
     // However, this leader has stop codons.  Therefore we put in a FAKE leader, that for
     // IGHV3-11.
+    //
+    // This code looks wrong because it does not modify refdata, but in fact it is OK.  We only
+    // use these extra references to infer the full length sequence of the entry.  Thereafter it
+    // is fine (and in fact better) to use our standard reference.
 
     refnames.push("IGHV3-43D".to_string());
     utr.push(false);

--- a/enclone_paper/src/bin/public_light_chain_analysis.rs
+++ b/enclone_paper/src/bin/public_light_chain_analysis.rs
@@ -267,12 +267,14 @@ fn main() {
         println!("\nCDRH3 length distribution for naive cells");
         let mut bins = vec![0; 100];
         let mut total = 0;
+        let mut total_len = 0;
         for k in 0..data.len() {
             let dref = data[k].dref;
             if dref == 0 {
                 let len = data[k].cdr3_aa1_len;
                 bins[len / 5] += 1;
                 total += 1;
+                total_len += len;
             }
         }
         for i in 0..bins.len() {
@@ -285,6 +287,7 @@ fn main() {
                 );
             }
         }
+        println!("mean CDRH3 length = {:.1}", total_len as f64 / total as f64);
     }
 
     // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓

--- a/enclone_paper/src/dperfect.rs
+++ b/enclone_paper/src/dperfect.rs
@@ -1,4 +1,4 @@
-// Given a human heavy chain junction region, report the longest perfect match by a human D gene to 
+// Given a human heavy chain junction region, report the longest perfect match by a human D gene to
 // the region, where the D gene can be placed within the region.
 
 use std::cmp::max;

--- a/enclone_paper/src/dperfect.rs
+++ b/enclone_paper/src/dperfect.rs
@@ -1,0 +1,25 @@
+// Given a human heavy chain junction region, report the longest perfect match by a human D gene to 
+// the region, where the D gene can be placed within the region.
+
+use std::cmp::max;
+
+pub fn dperfect(x: &[u8], ds: &Vec<Vec<u8>>) -> usize {
+    let mut best = 0;
+    for i in 0..ds.len() {
+        let d = &ds[i];
+        if x.len() >= d.len() {
+            for s in 0..=x.len() - d.len() {
+                let mut m = 0;
+                for j in 0..d.len() {
+                    if x[s + j] == d[j] {
+                        m += 1;
+                        best = max(best, m);
+                    } else {
+                        m = 0;
+                    }
+                }
+            }
+        }
+    }
+    best
+}

--- a/enclone_paper/src/lib.rs
+++ b/enclone_paper/src/lib.rs
@@ -1,3 +1,4 @@
 // Copyright (c) 2021 10x Genomics, Inc. All rights reserved.
 
+pub mod dperfect;
 pub mod public;

--- a/enclone_paper/src/public.rs
+++ b/enclone_paper/src/public.rs
@@ -204,4 +204,5 @@ pub fn public_print_results(
     for i in 0..r.len() {
         println!("{}", r[i]);
     }
+    println!("\npublic naive cells: {}\n", res_cell[0][10].0);
 }


### PR DESCRIPTION
- compute mean substitution rate for naive cells
- print number of public naive cells
- print CDRH3 mean length
- add dperfect tooling
- fix bug in which ann was passed to olga_splice instead of annv

STATUS: ./test passes.